### PR TITLE
Add GPS-based temperature and altitude defaults

### DIFF
--- a/Tecnam App/ContentView.swift
+++ b/Tecnam App/ContentView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import CoreLocation
 
 /// Represents the available runway surface types.  Values correspond to
 /// correction factors as described in the AFM.  Grass runways require a
@@ -190,6 +191,7 @@ private func interpolatePerformance(for weight: Double,
 
 struct ContentView: View {
     // MARK: - User Inputs
+    @StateObject private var locationManager = LocationManager()
     @State private var temperature: Double = 15.0 // °C
     @State private var altitude: Double = 0.0     // ft
     @State private var headwind: Double = 0.0    // knots.  Positive for headwind, negative for tailwind
@@ -425,6 +427,13 @@ struct ContentView: View {
                 }
             }
             .navigationTitle("P2010 Runway Calculator")
+        }
+        .onAppear { locationManager.requestLocation() }
+        .onReceive(locationManager.$fetchedTemperature) { temp in
+            if let temp = temp { self.temperature = temp }
+        }
+        .onReceive(locationManager.$fetchedAltitude) { alt in
+            if let alt = alt { self.altitude = alt }
         }
     }
 }

--- a/Tecnam App/Info.plist
+++ b/Tecnam App/Info.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>NSLocationWhenInUseUsageDescription</key>
+    <string>Used to populate the temperature and altitude fields from your current location.</string>
+</dict>
+</plist>

--- a/Tecnam App/LocationManager.swift
+++ b/Tecnam App/LocationManager.swift
@@ -1,0 +1,51 @@
+import Foundation
+import CoreLocation
+
+/// Handles location updates and retrieves local temperature and altitude.
+/// If available, publishes values in degrees Celsius and feet respectively.
+class LocationManager: NSObject, ObservableObject, CLLocationManagerDelegate {
+    private let manager = CLLocationManager()
+    @Published var fetchedTemperature: Double?
+    @Published var fetchedAltitude: Double?
+
+    override init() {
+        super.init()
+        manager.delegate = self
+    }
+
+    /// Request permission and a one‑time location update.
+    func requestLocation() {
+        manager.requestWhenInUseAuthorization()
+        manager.requestLocation()
+    }
+
+    func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
+        guard let location = locations.last else { return }
+        fetchWeather(for: location)
+    }
+
+    func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
+        print("Location error: \(error.localizedDescription)")
+    }
+
+    /// Calls a simple weather service to obtain temperature and site elevation.
+    private func fetchWeather(for location: CLLocation) {
+        let lat = location.coordinate.latitude
+        let lon = location.coordinate.longitude
+        guard let url = URL(string: "https://api.open-meteo.com/v1/forecast?latitude=\(lat)&longitude=\(lon)&current_weather=true") else {
+            return
+        }
+        URLSession.shared.dataTask(with: url) { data, _, _ in
+            guard let data = data,
+                  let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+                return
+            }
+            let temperature = (json["current_weather"] as? [String: Any])?["temperature"] as? Double
+            let elevation = json["elevation"] as? Double
+            DispatchQueue.main.async {
+                if let temperature = temperature { self.fetchedTemperature = temperature }
+                if let elevation = elevation { self.fetchedAltitude = elevation * 3.28084 }
+            }
+        }.resume()
+    }
+}


### PR DESCRIPTION
## Summary
- fetch device location once and query Open-Meteo for current temperature and field elevation
- populate temperature and altitude fields with fetched values while allowing manual overrides
- add Info.plist with location permission description

## Testing
- `swiftc 'Tecnam App/ContentView.swift' 'Tecnam App/LocationManager.swift'` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_b_68a461a699608330abcbf306d3ef0ea6